### PR TITLE
chore(deps): update ghcr tag/build to use @main instead of a pinned version

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build, Tag and Push Docker Image to GHCR
-        uses: GlueOps/github-actions-build-push-containers@v0.1.3
+        uses: GlueOps/github-actions-build-push-containers@main


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the GitHub Action in `.github/workflows/ghcr.yml` to use the `@main` branch instead of a specific version. This change ensures that the latest version of the GitHub Action is always used, potentially incorporating improvements and bug fixes.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ghcr.yml</strong><dd><code>Update GitHub Action to Use @main Branch for Docker Operations</code></dd></summary>
<hr>
      
.github/workflows/ghcr.yml

<li>Updated the GitHub Action used for building, tagging, and pushing <br>Docker images to use the <code>@main</code> branch instead of a pinned version <br>(<code>v0.1.3</code>).<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/metacontroller-operator-loki-rule-group/pull/19/files#diff-5a5a6cdb12aac9cd7553e275860b1b96aa9d63d20d556d0ce3a0cbace546c922">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

